### PR TITLE
Quality tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,16 @@ Pixel::resizeImage(imagePath,resizedImagePath,newWidth, newHeight, createPathIfN
 - Support for both local file paths and URLs.
 - Option to create the destination directory if it doesn't exist.
 - Error handling with detailed exceptions.
+
+## Change image quality tool
+
+```php
+Pixel::changeQuality(imagePath,resizedImagePath,quality, createPathIfNotExists = false)
+```
+
+### Features
+
+- Change the quality of JPEG and PNG images.
+- Support for both local file paths and URLs.
+- Option to create the destination directory if it doesn't exist.
+- Error handling with detailed exceptions.


### PR DESCRIPTION
## Pull Request Description

### Changes Made

- Added a new function `changeQuality` for modifying the quality of JPEG and PNG images.
- Extended the capabilities of the Pixel PHP library for image processing.

### Function Details

- **Function Name:** `changeQuality`
- **Parameters:**
  - `imagePath` (string): Path or URL to the original image.
  - `newImagePath` (string): Path to save the new image.
  - `quality` (int): Image quality (0-100) for JPEG format, compression level (0-9) for PNG format.
  - `createPathIfNotExists` (bool): Optional. Whether to create the directory if it doesn't exist. Default is `false`.
- **Supported Formats:**
  - JPEG (jpg, jpeg)
  - PNG (png)

### Usage Example

```php
require_once 'vendor/autoload.php';

use YourVendor\Pixel;

try {
    // Example: Change the quality of an image and save it to a new file
    Pixel::changeQuality('path/to/your/original/image.jpg', 'path/to/your/new/image.jpg', 80, true);
    echo 'Image quality changed successfully!';
} catch (\Exception $e) {
    echo 'Error: ' . $e->getMessage();
}
